### PR TITLE
Date type cast and suppress GUI messages

### DIFF
--- a/src/zcl_xtt_excel_xlsx.clas.locals_imp.abap
+++ b/src/zcl_xtt_excel_xlsx.clas.locals_imp.abap
@@ -652,7 +652,7 @@ CLASS cl_ex_sheet IMPLEMENTATION.
 
           " Date
         WHEN zcl_xtt_replace_block=>mc_type_date.
-          ASSIGN is_field->dref->* TO <l_date>.
+          ASSIGN is_field->dref->* TO <l_date> CASTING. " allow accept char(8) as date
           CLEAR ms_cell->c_type.
 
           " Time

--- a/src/zcl_xtt_xml_base.clas.abap
+++ b/src/zcl_xtt_xml_base.clas.abap
@@ -172,7 +172,16 @@ METHOD download.
   CONCATENATE lv_path lv_no_ext `.` mv_ole_ext INTO cv_fullpath.
 
   " Already exist. Add date and time
-  IF cl_gui_frontend_services=>file_exist( cv_fullpath ) = abap_true.
+  DATA lv_exist TYPE abap_bool.
+  cl_gui_frontend_services=>file_exist(
+    EXPORTING
+      file = cv_fullpath
+    RECEIVING
+      result = lv_exist
+    EXCEPTIONS
+      OTHERS = 0 "prevent GUI messages when file not found
+  ).
+  IF lv_exist = abap_true.
     CONCATENATE lv_path lv_no_ext ` ` sy-datum ` ` sy-uzeit `.` mv_ole_ext INTO cv_fullpath.
   ENDIF.
 


### PR DESCRIPTION
1) добавлен CASTING при присвоении C(8) в поле типа DATS. Без CASTING происходит дамп при ASSIGN. Пример:
`DATA: BEGIN OF gs_data
,   date_as_date TYPE d     VALUE '20200101'
,   date_as_char TYPE char8 VALUE '20200102'
, END OF gs_data.
DATA(lo_file) = CAST zif_xtt_file( NEW zcl_xtt_file_smw0( 'ZXTT_DATE_DUMP' ) ).
DATA(lo_xtt) = CAST zcl_xtt( NEW zcl_xtt_excel_xlsx( lo_file ) ).
lo_xtt->merge( is_block = gs_data   iv_block_name = 'R' ).
lo_xtt->show( ).`

В шаблоне XLSX  поля объявлены как {R-DATE_AS_DATE} и {R-DATE_AS_CHAR;type=date}

2) Если не указать EXCEPTIONS в вызове cl_gui_frontend_services=>file_exist(), будет всегда выводиться сообщение "Incorrect parameter: FILE_NAME"