### PR TITLE
Word-file is not downloaded

### DIFF
--- a/src/zcl_xtt_xml_base.clas.abap
+++ b/src/zcl_xtt_xml_base.clas.abap
@@ -526,6 +526,8 @@ METHOD zif_xtt~download.
    EXPORTING
      iv_open     = lv_open
      iv_zip      = iv_zip
+   IMPORTING
+     ev_content  = ev_content
    CHANGING
      cv_ole_app  = cv_ole_app
      cv_ole_doc  = cv_ole_doc


### PR DESCRIPTION
I try to download Word-file from template but it is not downloaded. I changed method ZIF_XTT~DOWNLOAD of class ZCL_XTT_XML_BASE and added parameter ev_content  = ev_content on call super->download