### PR TITLE
create_image: detect image extension by magic bytes

### DIFF
--- a/src/zcl_xtt_image.clas.abap
+++ b/src/zcl_xtt_image.clas.abap
@@ -102,10 +102,19 @@ METHOD create_image.
 
     " Set 1 time only
     ro_image->mv_image  = iv_image.
-    IF iv_ext IS INITIAL.
-      ro_image->mv_ext = '.jpeg'.
-    ELSE.
+    IF iv_ext IS NOT INITIAL.
       ro_image->mv_ext = iv_ext.
+    ELSE.
+      " No explicit extension: detect by magic bytes
+      CONSTANTS: lc_png_magic TYPE x LENGTH 4 VALUE '89504E47',
+                 lc_gif_magic TYPE x LENGTH 3 VALUE '474946'.
+      IF xstrlen( iv_image ) >= 4 AND iv_image(4) = lc_png_magic.
+        ro_image->mv_ext = '.png'.
+      ELSEIF xstrlen( iv_image ) >= 3 AND iv_image(3) = lc_gif_magic.
+        ro_image->mv_ext = '.gif'.
+      ELSE.
+        ro_image->mv_ext = '.jpeg'. " JPEG and unknown: previous behavior
+      ENDIF.
     ENDIF.
 
     DATA lv_cnt TYPE i.


### PR DESCRIPTION
When IV_EXT is not supplied, `create_image` always assumed `.jpeg`. Now PNG (`89504E47`) and GIF (`474946`) are detected from the first bytes of the image; JPEG and unknown formats keep the previous default, so existing behavior does not change for them.

Verified end-to-end: a GIF passed via `{R-T-RAW;type=image}` is now stored as `xl/media/_img1.gif` in the produced xlsx (was `_img1.jpeg`).

P.S. from Maxim: this came out of running xtt on the abaplint transpiler stack without a SAP system — the whole engine works there, I will show you the setup.