### PR TITLE
xlsx: read inline strings and accept absolute relationship targets

### DIFF
--- a/src/zcl_xtt_excel_xlsx.clas.abap
+++ b/src/zcl_xtt_excel_xlsx.clas.abap
@@ -509,7 +509,7 @@ METHOD cell_read_xml.
   IF lo_elem IS BOUND.
     l_val = lo_elem->get_value( ).
   ELSE.
-    l_val = io_node->get_value( ).  " TODO 'inlineStr' !!! with tags!
+    l_val = io_node->get_value( ).
   ENDIF.
 
   CASE ls_cell->c_type.
@@ -518,7 +518,26 @@ METHOD cell_read_xml.
       READ TABLE it_shared_strings INTO ls_cell->c_value INDEX l_ind.
 
     WHEN 'inlineStr'.
-      ls_cell->c_value = l_val. " <si> tag get_without_t(  ).
+      " The text of an inline string is in <is><t>, not in <v>; rich text
+      " splits it over several <r><t> runs, so concatenate all of them
+      CLEAR l_val.
+      DATA lo_is TYPE REF TO if_ixml_element.
+      lo_is ?= io_node->find_from_name( name = 'is' ).
+      IF lo_is IS BOUND.
+        DATA lo_texts TYPE REF TO if_ixml_node_collection.
+        DATA lo_titer TYPE REF TO if_ixml_node_iterator.
+        DATA lo_tnode TYPE REF TO if_ixml_node.
+        lo_texts = lo_is->get_elements_by_tag_name( name = 't' ).
+        lo_titer = lo_texts->create_iterator( ).
+        DO.
+          lo_tnode = lo_titer->get_next( ).
+          IF lo_tnode IS NOT BOUND.
+            EXIT.
+          ENDIF.
+          CONCATENATE l_val lo_tnode->get_value( ) INTO l_val.
+        ENDDO.
+      ENDIF.
+      ls_cell->c_value = l_val.
       ls_cell->c_type  = 's'.
 
     WHEN OTHERS.

--- a/src/zcl_xtt_excel_xlsx.clas.locals_imp.abap
+++ b/src/zcl_xtt_excel_xlsx.clas.locals_imp.abap
@@ -11,12 +11,17 @@ CLASS lcl_ex_sheet IMPLEMENTATION.
     WHILE lo_node IS BOUND.
       DATA lv_target TYPE string.
       lv_target = lo_node->get_attribute( 'Target' ).
-      IF lv_target CP 'worksheets/sheet*'.
-        REPLACE FIRST OCCURRENCE OF: 'worksheets/sheet' IN lv_target WITH ``,
-                                     '.xml'             IN lv_target WITH ``.
+      " The Target may be relative ('worksheets/sheet1.xml') or an absolute
+      " part name ('/xl/worksheets/sheet1.xml') - both are valid OPC, and
+      " writers other than Excel do use the absolute form
+      IF lv_target CS 'worksheets/sheet'.
+        DATA lv_before TYPE string.
+        DATA lv_number TYPE string.
+        SPLIT lv_target AT 'worksheets/sheet' INTO lv_before lv_number.
+        REPLACE FIRST OCCURRENCE OF '.xml' IN lv_number WITH ``.
 
         DATA lv_index TYPE syindex.
-        lv_index = lv_target.
+        lv_index = lv_number.
         APPEND lv_index TO rt_index.
       ENDIF.
 


### PR DESCRIPTION
Two independent findings from running xtt on templates produced by openpyxl instead of Excel.

**1) Absolute relationship targets (a real bug)**

`get_sheet_indices` matches `Target CP 'worksheets/sheet*'`. OPC also allows the absolute part name `Target="/xl/worksheets/sheet1.xml"`, which openpyxl writes. No sheet is then found and `merge` returns the workbook unchanged — without an error or a log entry, so the template just silently comes back empty. Now both forms are matched.

**2) inlineStr (the TODO in the code)**

The value of `<c t="inlineStr">` lives in `<is><t>`, not in `<v>`; `cell_read_xml` took it from the cell node itself, which is what the `" TODO 'inlineStr' !!! with tags!` comment refers to. The `<is>` subtree is now read explicitly and all `<t>` of a rich-text run are concatenated.

To be precise about this half: on the abaplint transpiler stack the old code happens to work, because that iXML implementation concatenates descendant text — so I cannot show a failing case there, and I am submitting it as the TODO being closed rather than as a reproduced bug. On SAP iXML `get_value( )` of an element does not return the text of nested elements, which is what the comment warns about.

Both paths are covered by tests in the transpiler harness (https://github.com/kenzhemax/xtt-ci): a template whose marker is stored as an inline string, and one whose relationships use absolute targets. The second fails before this change.